### PR TITLE
add trailing / in Keycloak_url

### DIFF
--- a/fastapi/src/app/authorize/keycloak.py
+++ b/fastapi/src/app/authorize/keycloak.py
@@ -24,7 +24,7 @@ class KeycloakAuth:
     def __init__(self):
         self.client_id = os.getenv('CLIENT_ID', 'demo-api')
         self.client_secret = os.getenv('CLIENT_SECRET', 'censored')
-        self.keycloak_url = os.getenv('KEYCLOAK_URL', 'https://demo-keycloak.gruppe.ai')
+        self.keycloak_url = os.getenv('KEYCLOAK_URL', 'https://demo-keycloak.gruppe.ai/')
         self.realm = os.getenv('REALM', 'demo')
         self.required_role = "IT-Admin"
 


### PR DESCRIPTION
Fix the error from the demo presentation. 

When setting the values in .env for the fastapi this is also important. 

the Keycloak_url `https://demo-keycloak.gruppe.ai/` needs a trailing /.